### PR TITLE
Normalization of work with Meta. Now Meta can have two kinds, the fir…

### DIFF
--- a/src/Atom.php
+++ b/src/Atom.php
@@ -60,7 +60,7 @@ class Atom
 
         $this->metaType = $metaType;
         $this->metaId = $metaId;
-        $this->meta = $meta ?: [];
+        $this->meta = $meta ? static::normalizeMeta( $meta ) : [];
 
         $this->otsFragment = $otsFragment;
         $this->createdAt = ( string ) time();
@@ -102,7 +102,7 @@ class Atom
                     }
 
                     if ( 'meta' === $name ) {
-                        $list = array_map( static function ( $key, $val ) { return is_array( $val ) ? $val : ['key' => $key, 'value' => $val]; }, array_keys( $value ), array_values( $value ) );
+                        $list = static::normalizeMeta( $value );
 
                         foreach ( $list as $meta ) {
                             $molecularSponge->absorb( ( string ) $meta['key']);
@@ -147,5 +147,14 @@ class Atom
         }
 
         return $target;
+    }
+
+    /**
+     * @param array $meta
+     * @return array
+     */
+    public static function normalizeMeta ( array $meta )
+    {
+        return array_map( static function ( $key, $val ) { return is_array( $val ) ? $val : ['key' => $key, 'value' => $val]; }, array_keys( $meta ), array_values( $meta ) );
     }
 }

--- a/src/Molecule.php
+++ b/src/Molecule.php
@@ -112,7 +112,9 @@ class Molecule
      */
     public function initTokenCreation ( Wallet $sourceWallet, Wallet $recipientWallet, $amount, array $tokenMeta )
     {
-        if ( !array_key_exists( 'walletAddress', $tokenMeta ) ) {
+        $hasWalletAddress = array_filter( $tokenMeta, static function ( $token ) { return is_array( $token ) && array_key_exists('key', $token ) && 'walletAddress' === $token['key']; } );
+
+        if ( empty( $hasWalletAddress ) && !array_key_exists( 'walletAddress', $tokenMeta ) ) {
 
             $tokenMeta['walletAddress'] = $recipientWallet->address;
         }


### PR DESCRIPTION
…st [['key' => 'val','value' => 'val'], ['key' => 'val', 'value' => 'val']] or the second ['foo' => 'too', 'too' => 'foo']. In requests to the server will always be the first option.